### PR TITLE
feat: add key-hash, gendata-mrenclave and quote-data utils

### DIFF
--- a/src/intel_sgx_ra/cli/utils.py
+++ b/src/intel_sgx_ra/cli/utils.py
@@ -1,13 +1,29 @@
 """intel_sgx_ra.cli.tools module."""
 
 import argparse
+import hashlib
 import logging
 import sys
 from pathlib import Path
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from intel_sgx_ra.css import gendata_from_file
 from intel_sgx_ra.error import CommandNotFound
 from intel_sgx_ra.quote import Quote
 from intel_sgx_ra.ratls import get_quote_from_cert, get_server_certificate, url_parse
+
+
+def rsa_pubkey_hash_from_pem(path: Path) -> bytes:
+    """Compute the SHA256 hash of the RSA-3072 public key modulus from a PEM file."""
+    pem = path.resolve().read_bytes()
+    pub = serialization.load_pem_public_key(pem)
+    if not isinstance(pub, rsa.RSAPublicKey):
+        raise ValueError("The provided PEM file does not contain an RSA public key")
+    n = pub.public_numbers().n  # RSA modulus (int)
+    modulus = n.to_bytes(384, "little", signed=False)  # 384 bytes, big-endian
+    return hashlib.sha256(modulus).digest()
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,15 +53,41 @@ def parse_args() -> argparse.Namespace:
         help="HTTPS URL to fetch server's certificate",
     )
 
+    extract_data_parser = subparsers.add_parser(
+        "quote-data", help="Extract data from Intel SGX quote"
+    )
+    extract_data_parser.add_argument(
+        "QUOTE", type=Path, help="Path to the Intel SGX quote binary file"
+    )
+    extract_data_parser.add_argument(
+        "--hex", action="store_true", help="Hexadecimal output format"
+    )
+
+    key_hash_parser = subparsers.add_parser(
+        "key-hash", help="Compute RSA public key hash from PEM file"
+    )
+    key_hash_parser.add_argument(
+        "PEM", type=Path, help="Path to the RSA-3072 public key in PEM format"
+    )
+    key_hash_parser.add_argument(
+        "--hex", action="store_true", help="Hexadecimal output format"
+    )
+
+    gendata_parser = subparsers.add_parser(
+        "gendata-mrenclave", help="Extract MRENCLAVE from CSS GENDATA file"
+    )
+    gendata_parser.add_argument(
+        "GENDATA", type=Path, help="Path to the CSS GENDATA binary file"
+    )
+    gendata_parser.add_argument(
+        "--hex", action="store_true", help="Hexadecimal output format"
+    )
+
     return parser.parse_args()
 
 
-# pylint: disable=too-many-branches
-def run() -> None:
-    """Entrypoint of the CLI."""
-    logging.basicConfig(format="%(message)s", level=logging.INFO)
-    args = parse_args()
-
+def extract_quote_from_cert(args):
+    """Extract Intel SGX quote from RA-TLS X.509 certificate."""
     quote: Quote
 
     if args.path:
@@ -62,3 +104,53 @@ def run() -> None:
     args.OUTPUT.write_bytes(bytes(quote))
 
     sys.exit(0)
+
+
+def extract_quote_data(args):
+    """Extract report data from Intel SGX quote."""
+    quote_path: Path = args.QUOTE.resolve()
+    quote = Quote.from_bytes(quote_path.read_bytes())
+    if args.hex:
+        print(quote.report_body.report_data.hex())
+    else:
+        sys.stdout.buffer.write(quote.report_body.report_data)
+    sys.exit(0)
+
+
+def pubkey_pem_to_hash(args):
+    """Compute RSA-3072 public key hash (MRSIGNER) from PEM file."""
+    key_hash = rsa_pubkey_hash_from_pem(args.PEM)
+    if args.hex:
+        print(key_hash.hex())
+    else:
+        sys.stdout.buffer.write(key_hash)
+    sys.exit(0)
+
+
+def extract_mrenclave_from_gendata(args):
+    """Extract MRENCLAVE from gendata code signing structure file."""
+    gendata = gendata_from_file(args.GENDATA)
+    mr_enclave = bytes(gendata.body.enclave_hash)
+    if args.hex:
+        print(mr_enclave.hex())
+    else:
+        sys.stdout.buffer.write(mr_enclave)
+    sys.exit(0)
+
+
+# pylint: disable=too-many-branches
+def run() -> None:
+    """Entrypoint of the CLI."""
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stderr)
+    args = parse_args()
+
+    if args.command == "extract":
+        extract_quote_from_cert(args)
+    elif args.command == "quote-data":
+        extract_quote_data(args)
+    elif args.command == "key-hash":
+        pubkey_pem_to_hash(args)
+    elif args.command == "gendata-mrenclave":
+        extract_mrenclave_from_gendata(args)
+    else:
+        raise CommandNotFound("Bad subcommand!")

--- a/src/intel_sgx_ra/css.py
+++ b/src/intel_sgx_ra/css.py
@@ -1,0 +1,88 @@
+"""Module for handling Intel SGX code signing structures (CSS)."""
+
+import ctypes
+from pathlib import Path
+
+# CSS is short for code signing structure. It is used to sign Intel SGX enclaves.
+# Inside, SGXDataCenterAttestationPrimitives/SampleCode/QuoteGenerationSample,
+# adapt the Makefile to not delete the unsigned enclave.so file.
+# Afterwards, you can generate the gendata (CSS) file as follows:
+# /opt/intel/sgxsdk/bin/x64/sgx_sign gendata -enclave enclave.so \
+# -config Enclave/Enclave.config.xml -o gendata
+
+
+class CssHeader(ctypes.Structure):
+    """Intel SGX Code Signing Structure (CSS) Header."""
+
+    _fields_ = [
+        ("header", ctypes.c_uint8 * 12),
+        ("type", ctypes.c_uint32),
+        ("module_vendor", ctypes.c_uint32),
+        ("date", ctypes.c_uint32),
+        ("header2", ctypes.c_uint8 * 16),
+        ("hw_version", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint8 * 84),
+    ]
+
+    _pack_ = 1  # ensure no padding
+
+
+assert ctypes.sizeof(CssHeader) == 128
+
+
+class CssBody(ctypes.Structure):
+    """Intel SGX Code Signing Structure (CSS) Body."""
+
+    _fields_ = [
+        ("misc_select", ctypes.c_uint32),
+        ("misc_mask", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint8 * 4),
+        ("isv_family_id", ctypes.c_uint8 * 16),
+        ("attributes", ctypes.c_uint64 * 2),
+        ("attribute_mask", ctypes.c_uint64 * 2),
+        ("enclave_hash", ctypes.c_uint8 * 32),
+        ("reserved2", ctypes.c_uint8 * 16),
+        ("isvext_prod_id", ctypes.c_uint8 * 16),
+        ("isv_prod_id", ctypes.c_uint16),
+        ("isv_svn", ctypes.c_uint16),
+    ]
+
+    _pack_ = 1  # ensure no padding
+
+
+assert ctypes.sizeof(CssBody) == 128
+
+
+class Gendata(ctypes.Structure):
+    """Intel SGX Code Signing Structure (CSS)."""
+
+    _fields_ = [
+        ("header", CssHeader),
+        ("body", CssBody),
+    ]
+
+    _pack_ = 1  # ensure no padding
+
+
+assert ctypes.sizeof(Gendata) == 256
+
+
+def gendata_from_file(path: Path) -> Gendata:
+    """Read the gendata structure from a binary file.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the gendata file.
+
+    Returns
+    -------
+    Gendata
+        The code signing structure from the specified file.
+
+    """
+    data = path.resolve().read_bytes()
+    if len(data) != ctypes.sizeof(Gendata):
+        raise ValueError("File size does not match gendata structure size")
+    gendata = Gendata.from_buffer_copy(data)
+    return gendata


### PR DESCRIPTION
This commit adds three utility functions:
1. `quote-data`, which extracts the data field from a quote.
2. `key-hash`, which converts an RSA public key to a MRSIGNER value.
3. `gendata-mrenclave`, which extracts the MRCENCLAVE field from a code signing structure. This is useful for verifying reproducible builds.

They could be used as follows:
```
sgx-ra-verify \
  --mrenclave "$(sgx-ra-utils gendata-mrenclave --hex css.bin)" \
  --mrsigner "$(sgx-ra-utils key-hash --hex public.key)" \
  --pccs-url http://127.0.0.1:8080 \
  quote quote.dat
```